### PR TITLE
new version

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '12'
+- '13'
 cfitsio:
 - 4.1.0
 channel_sources:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '12'
+- '13'
 fftw:
 - '3'
 fortran_compiler:
@@ -27,7 +27,7 @@ libblas:
 liblapack:
 - 3.8 *netlib
 llvm_openmp:
-- '12'
+- '13'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 pin_run_as_build:

--- a/README.md
+++ b/README.md
@@ -67,16 +67,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `tempo2` can be installed with:
+Once the `conda-forge` channel has been enabled, `tempo2` can be installed with `conda`:
 
 ```
 conda install tempo2
 ```
 
-It is possible to list all of the versions of `tempo2` available on your platform with:
+or with `mamba`:
+
+```
+mamba install tempo2
+```
+
+It is possible to list all of the versions of `tempo2` available on your platform with `conda`:
 
 ```
 conda search tempo2 --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search tempo2 --channel conda-forge
+```
+
+Alternatively, `mamba repoquery` may provide more information:
+
+```
+# Search all versions available on your platform:
+mamba repoquery search tempo2 --channel conda-forge
+
+# List packages depending on `tempo2`:
+mamba repoquery whoneeds tempo2 --channel conda-forge
+
+# List dependencies of `tempo2`:
+mamba repoquery depends tempo2 --channel conda-forge
 ```
 
 
@@ -94,10 +119,12 @@ for each of the installable packages. Such a repository is known as a *feedstock
 A feedstock is made up of a conda recipe (the instructions on what and how to build
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
-[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
-packages to the [conda-forge](https://anaconda.org/conda-forge)
-[Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
+[Azure](https://azure.microsoft.com/en-us/services/devops/), [GitHub](https://github.com/),
+[CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/),
+[Drone](https://cloud.drone.io/welcome), and [TravisCI](https://travis-ci.com/)
+it is possible to build and upload installable packages to the
+[conda-forge](https://anaconda.org/conda-forge) [Anaconda-Cloud](https://anaconda.org/)
+channel for Linux, Windows and OSX respectively.
 
 To manage the continuous integration and simplify feedstock maintenance
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tempo2" %}
-{% set version = "2020.05.1" %}
+{% set version = "2022.05.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -9,7 +9,7 @@ source:
   # for "Download" versions use:
   #url: "https://bitbucket.org/psrsoft/{{ name }}/downloads/{{ name }}-{{ version }}.tar.gz"
   # for versions that don't exist in "Download" but are tagged use:
-  url: https://bitbucket.org/psrsoft/{{ name }}/get/{{ version }}.tar.gz
+  url: https://bitbucket.org/psrsoft/{{ name }}/get/2020.05.1.tar.gz
   # for versions based on an untagged git hash (required for v2021.07.1) use:
   #url: https://bitbucket.org/psrsoft/{{ name }}/get/e6fb8ca69895.tar.gz
   sha256: 34f83654ac5a0e6d0c72e779aa4bda9cd1bd3bd5220a3c6199746cdaa72261f5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tempo2" %}
-{% set version = "2022.01.1" %}
+{% set version = "2020.05.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -12,10 +12,10 @@ source:
   url: https://bitbucket.org/psrsoft/{{ name }}/get/{{ version }}.tar.gz
   # for versions based on an untagged git hash (required for v2021.07.1) use:
   #url: https://bitbucket.org/psrsoft/{{ name }}/get/e6fb8ca69895.tar.gz
-  sha256: 389543a9a53b601606458f1fd76f4c18803d9b18bd4c2c6e4371aa61f81b956d
+  sha256: 34f83654ac5a0e6d0c72e779aa4bda9cd1bd3bd5220a3c6199746cdaa72261f5
 
 build:
-  number: 2
+  number: 0
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


The new tag `2020.05.1` is actually a typo by the `tempo2` developers and must be `2022.05.1` [instead]( https://bitbucket.org/psrsoft/tempo2/src/2020.05.1/ ). 
This new version fixes a bug that I had seen in the previous version/tag (see [this]( https://bitbucket.org/psrsoft/tempo2/issues/87/bug-in-2022011-tag))