### PR TITLE
Enable osx-arm64 build and update build config

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -18,6 +18,16 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
+      osx_arm64_:
+        CONFIG: osx_arm64_
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15-arm64
+        build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma10
 fftw:
@@ -23,7 +23,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 gsl:
 - '2.8'
 libblas:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -15,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le:alma10
 fftw:
@@ -23,7 +23,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 gsl:
 - '2.8'
 libblas:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -19,7 +19,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '21'
 fftw:
 - '3'
 fortran_compiler:
@@ -33,7 +33,7 @@ libblas:
 liblapack:
 - 3.9.* *netlib
 llvm_openmp:
-- '17'
+- '21'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -25,7 +25,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '14'
+- '15'
 gsl:
 - '2.8'
 libblas:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,11 +1,15 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '15'
+- '17'
 c_stdlib:
-- sysroot
+- macosx_deployment_target
 c_stdlib_version:
-- '2.17'
+- '11.0'
 cfitsio:
 - 4.6.4
 channel_sources:
@@ -13,11 +17,9 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '15'
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma10
+- '17'
 fftw:
 - '3'
 fortran_compiler:
@@ -30,8 +32,12 @@ libblas:
 - 3.9.* *netlib
 liblapack:
 - 3.9.* *netlib
+llvm_openmp:
+- '17'
+macos_machine:
+- arm64-apple-darwin20.0.0
 target_platform:
-- linux-64
+- osx-arm64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '17'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -19,7 +19,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '17'
+- '21'
 fftw:
 - '3'
 fortran_compiler:
@@ -33,7 +33,7 @@ libblas:
 liblapack:
 - 3.9.* *netlib
 llvm_openmp:
-- '17'
+- '21'
 macos_machine:
 - arm64-apple-darwin20.0.0
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -49,6 +49,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -32,11 +32,19 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list --environment docker-build-linux-$arch
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -50,7 +58,7 @@ source run_conda_forge_build_setup
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
 fi
 
 
@@ -67,15 +75,16 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     #   - --output-id vs. --output-name
     #   - --clobber-file vs. none
     #   - none vs. --target-platform
-    CONDA_SUBDIR="${BUILD_PLATFORM}" conda debug \
-        "${RECIPE_ROOT}" \
+    export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT}/build_artifacts}"
+    rattler-build debug setup \
+        --recipe "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
-        ${BUILD_OUTPUT_ID:+--output-id "${BUILD_OUTPUT_ID}"} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
+        ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        --build-platform "${BUILD_PLATFORM}" \
+        --target-platform "${HOST_PLATFORM}"
 
-    # Drop into an interactive shell
-    /bin/bash
+    rattler-build debug shell
 else
     # differences between conda-build vs. rattler-build
     #   - recipe is positional vs. --recipe "${RECIPE_ROOT}"
@@ -83,13 +92,16 @@ else
     #   - --clobber-file vs. none
     #   - none vs. --target-platform
     #   - --extra-meta a=b c=d vs. --extra-meta a=b --extra-meta c=d
-    CONDA_SUBDIR="${BUILD_PLATFORM}" conda-build \
-        "${RECIPE_ROOT}" \
+
+    rattler-build build \
+        --recipe "${RECIPE_ROOT}" \
         -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         ${EXTRA_CB_OPTIONS:-} \
-        --suppress-variables \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+        --build-platform "${BUILD_PLATFORM}" \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="${flow_run_id:-}" \
+        --extra-meta remote_url="${remote_url:-}" \
+        --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -9,34 +9,24 @@ set -xe
 MINIFORGE_HOME="${MINIFORGE_HOME:-${HOME}/miniforge3}"
 MINIFORGE_HOME="${MINIFORGE_HOME%/}" # remove trailing slash
 export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${MINIFORGE_HOME}/conda-bld}"
-
-( startgroup "Provisioning base env with micromamba" ) 2> /dev/null
-MICROMAMBA_VERSION="1.5.10-0"
-if [[ "$(uname -m)" == "arm64" ]]; then
-  osx_arch="osx-arm64"
-else
-  osx_arch="osx-64"
+( startgroup "Provisioning base env with pixi" ) 2> /dev/null
+mkdir -p "${MINIFORGE_HOME}"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
 fi
-MICROMAMBA_URL="https://github.com/mamba-org/micromamba-releases/releases/download/${MICROMAMBA_VERSION}/micromamba-${osx_arch}"
-MAMBA_ROOT_PREFIX="${MINIFORGE_HOME}-micromamba-$(date +%s)"
-echo "Downloading micromamba ${MICROMAMBA_VERSION}"
-micromamba_exe="$(mktemp -d)/micromamba"
-curl -L -o "${micromamba_exe}" "${MICROMAMBA_URL}"
-chmod +x "${micromamba_exe}"
+sed -i.bak "s/platforms = .*/platforms = [\"osx-${arch}\"]/" pixi.toml
 echo "Creating environment"
-"${micromamba_exe}" create --yes --root-prefix "${MAMBA_ROOT_PREFIX}" --prefix "${MINIFORGE_HOME}" \
-  --channel conda-forge \
-  pip python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=26.3"
-echo "Moving pkgs cache from ${MAMBA_ROOT_PREFIX} to ${MINIFORGE_HOME}"
-mv "${MAMBA_ROOT_PREFIX}/pkgs" "${MINIFORGE_HOME}"
-echo "Cleaning up micromamba"
-rm -rf "${MAMBA_ROOT_PREFIX}" "${micromamba_exe}" || true
-( endgroup "Provisioning base env with micromamba" ) 2> /dev/null
+pixi install --environment build
+pixi list --environment build
+echo "Activating environment"
+eval "$(pixi shell-hook --environment build)"
+mv pixi.toml.bak pixi.toml
+( endgroup "Provisioning base env with pixi" ) 2> /dev/null
 
 ( startgroup "Configuring conda" ) 2> /dev/null
-echo "Activating environment"
-source "${MINIFORGE_HOME}/etc/profile.d/conda.sh"
-conda activate base
 export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
@@ -89,33 +79,35 @@ source run_conda_forge_build_setup
 
 ( endgroup "Configuring conda" ) 2> /dev/null
 
-echo -e "\n\nMaking the build clobber file"
-make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    CONDA_SUBDIR="${BUILD_PLATFORM}" conda debug ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+    export CONDA_BLD_PATH="${CONDA_BLD_PATH:-${FEEDSTOCK_ROOT:-$PWD}/build_artifacts}"
+    rattler-build debug setup \
+        --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        --build-platform "${BUILD_PLATFORM}" \
+        --target-platform "${HOST_PLATFORM}" \
+        ${BUILD_OUTPUT_ID:+--output-name "${BUILD_OUTPUT_ID}"} \
+        ${EXTRA_CB_OPTIONS:-}
 
-    # Drop into an interactive shell
-    /bin/bash
+    rattler-build debug shell
 else
 
     if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --test skip"
     fi
 
-    CONDA_SUBDIR="${BUILD_PLATFORM}" conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
-        --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"
+    rattler-build build --recipe ./recipe \
+        -m ./.ci_support/${CONFIG}.yaml \
+        ${EXTRA_CB_OPTIONS:-} \
+        --build-platform "${BUILD_PLATFORM}" \
+        --target-platform "${HOST_PLATFORM}" \
+        --extra-meta flow_run_id="$flow_run_id" \
+        --extra-meta remote_url="$remote_url" \
+        --extra-meta sha="$sha"
 
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -108,6 +108,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     CONDA_SUBDIR="${BUILD_PLATFORM}" conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempo2-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>osx_arm64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=11402&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/tempo2-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@ About tempo2-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tempo2-feedstock/blob/main/LICENSE.txt)
 
-Home: https://bitbucket.org/psrsoft/tempo2/
+Home: https://bitbucket.org/psrsoft/tempo2
 
 Package license: GPL-3.0-or-later
 
 Summary: Tempo2 is a high precision pulsar timing tool. Tempo2 is not tempo3 either.
 
-Development: https://bitbucket.org/psrsoft/tempo2/
+Development: https://bitbucket.org/psrsoft/tempo2
+
+Documentation: https://bitbucket.org/psrsoft/tempo2/src/2026.04.1/documentation
 
 Current build status
 ====================

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -7,3 +7,5 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
+  osx_arm64: default
+test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,8 @@
 conda_build:
   pkg_format: '2'
 conda_forge_output_validation: true
+conda_build_tool: rattler-build
+conda_install_tool: pixi
 github:
   branch_name: main
   tooling_branch_name: main

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,89 @@
+# -*- mode: toml -*-
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+"$schema" = "https://pixi.sh/v0.59.0/schema/manifest/schema.json"
+
+[workspace]
+name = "tempo2-feedstock"
+version = "2026.8.9"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/tempo2-feedstock"
+authors = ["@conda-forge/tempo2"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "linux-aarch64", "linux-ppc64le", "osx-64", "osx-arm64", "win-64"]
+requires-pixi = ">=0.59.0"
+
+[tasks.build-locally]
+cmd = "pixi exec --force-reinstall --list='^python$' python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[tasks.smithy]
+cmd = "pixi exec --force-reinstall --list='^conda-smithy$' conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[tasks.rerender]
+cmd = "pixi exec --force-reinstall --list='^conda-smithy$' conda-smithy rerender"
+description = "Rerender the feedstock."
+
+[tasks.lint]
+cmd = "pixi exec --list='^conda-smithy$' conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[feature.build.dependencies]
+conda-build = ">=26.3"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[feature.build.tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[feature.build.tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build tempo2-feedstock directly (without setup scripts), no particular variant specified"
+[feature.build.tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build tempo2-feedstock with variant linux_64_ directly (without setup scripts)"
+[feature.build.tasks."debug-linux_64_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build tempo2-feedstock with variant linux_64_ directly (without setup scripts)"
+[feature.build.tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of tempo2-feedstock packages built for variant linux_64_"
+[feature.build.tasks."build-linux_aarch64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_aarch64_.yaml"
+description = "Build tempo2-feedstock with variant linux_aarch64_ directly (without setup scripts)"
+[feature.build.tasks."debug-linux_aarch64_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/linux_aarch64_.yaml"
+description = "Build tempo2-feedstock with variant linux_aarch64_ directly (without setup scripts)"
+[feature.build.tasks."inspect-linux_aarch64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_aarch64_.yaml"
+description = "List contents of tempo2-feedstock packages built for variant linux_aarch64_"
+[feature.build.tasks."build-linux_ppc64le_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_ppc64le_.yaml"
+description = "Build tempo2-feedstock with variant linux_ppc64le_ directly (without setup scripts)"
+[feature.build.tasks."debug-linux_ppc64le_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/linux_ppc64le_.yaml"
+description = "Build tempo2-feedstock with variant linux_ppc64le_ directly (without setup scripts)"
+[feature.build.tasks."inspect-linux_ppc64le_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_ppc64le_.yaml"
+description = "List contents of tempo2-feedstock packages built for variant linux_ppc64le_"
+[feature.build.tasks."build-osx_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_64_.yaml"
+description = "Build tempo2-feedstock with variant osx_64_ directly (without setup scripts)"
+[feature.build.tasks."debug-osx_64_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/osx_64_.yaml"
+description = "Build tempo2-feedstock with variant osx_64_ directly (without setup scripts)"
+[feature.build.tasks."inspect-osx_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_64_.yaml"
+description = "List contents of tempo2-feedstock packages built for variant osx_64_"
+[feature.build.tasks."build-osx_arm64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/osx_arm64_.yaml"
+description = "Build tempo2-feedstock with variant osx_arm64_ directly (without setup scripts)"
+[feature.build.tasks."debug-osx_arm64_"]
+cmd = "rattler-build debug setup --recipe recipe -m .ci_support/osx_arm64_.yaml"
+description = "Build tempo2-feedstock with variant osx_arm64_ directly (without setup scripts)"
+[feature.build.tasks."inspect-osx_arm64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/osx_arm64_.yaml"
+description = "List contents of tempo2-feedstock packages built for variant osx_arm64_"
+
+[environments]
+build = ["build"]
+# This is a copy of 'build', to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = ["build"]

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,7 @@
 #echo "CXXFLAGS $CXXFLAGS"
 
 export TEMPO2=$PREFIX/share/tempo2
+export CFLAGS="${CFLAGS} -std=gnu17"
 
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* ./tests/gtest-1.7.0/build-aux

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,10 @@
 #echo "CXXFLAGS $CXXFLAGS"
 
 export TEMPO2=$PREFIX/share/tempo2
+
+# Get an updated config.sub and config.guess
+cp $BUILD_PREFIX/share/gnuconfig/config.* ./tests/gtest-1.7.0/build-aux
+
 ./bootstrap
 ./configure --prefix=$PREFIX --disable-local --disable-psrhome PGPLOT_DIR=$PREFIX/include/pgplot
 make -j${CPU_COUNT}

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,0 @@
-c_compiler_version:    # [osx]
-  - "17"               # [osx]
-cxx_compiler_version:  # [osx]
-  - "17"               # [osx]
-llvm_openmp:           # [osx]
-  - "17"               # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0002-interpolate-std.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - {{ compiler('fortran') }}
     - autoconf
     - automake
+    - gnuconfig
     - libtool
     - make      # [unix]
   host:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,11 +1,10 @@
 schema_version: 1
 
 context:
-  name: tempo2
   version: "2026.04.1"
 
 package:
-  name: ${{ name|lower }}
+  name: tempo2
   version: ${{ version }}
 
 source:
@@ -14,7 +13,7 @@ source:
   # for versions that don't exist in "Download" but are tagged use:
   # for versions based on an untagged git hash (required for v2021.07.1) use:
   #url: https://bitbucket.org/psrsoft/{{ name }}/get/d072c424de34f50d0627c4ca9f8b4ec40a791e07.tar.gz
-  url: https://bitbucket.org/psrsoft/${{ name }}/get/${{ version }}.tar.gz
+  url: https://bitbucket.org/psrsoft/tempo2/get/${{ version }}.tar.gz
   sha256: 25b8e164cda4637da1b479a837dfc5528821b5774073ccdb2c080fbcef826bd3
   patches:
     - 0001-package-m4.patch

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -52,6 +52,8 @@ requirements:
     - liblapack
     - if: osx
       then: llvm-openmp
+  run_exports:
+    - ${{ pin_subpackage("tempo2", upper_bound="x.x.x") }}
 
 tests:
   - package_contents:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -54,13 +54,26 @@ requirements:
       then: llvm-openmp
 
 tests:
-  - files:
-      source:
-        - tests/test_data/test_de430.par
-        - tests/test_data/test_de430.tim
+  - package_contents:
+      bin:
+        - tempo2
+        - getPeriod
+      lib:
+        - tempo2
+        - tempo2pred
+        - t2toolkit
+        - sofa
+      include:
+        - tempo2.h
+        - tempo2pred.h
+        - T2toolkit.h
   - script:
       - if: not ppc64le
         then: tempo2 -f tests/test_data/test_de430.par tests/test_data/test_de430.tim
+    files:
+      source:
+        - tests/test_data/test_de430.par
+        - tests/test_data/test_de430.tim
 
 about:
   homepage: https://bitbucket.org/psrsoft/tempo2
@@ -75,4 +88,3 @@ extra:
     - demorest
     - sixbynine
     - mattpitkin
-

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,17 +1,20 @@
-{% set name = "tempo2" %}
-{% set version = "2026.04.1" %}
+schema_version: 1
+
+context:
+  name: tempo2
+  version: "2026.04.1"
 
 package:
-  name: "{{ name|lower }}"
-  version: "{{ version }}"
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
   # for "Download" versions use:
   #url: "https://bitbucket.org/psrsoft/{{ name }}/downloads/{{ name }}-{{ version }}.tar.gz"
   # for versions that don't exist in "Download" but are tagged use:
-  url: https://bitbucket.org/psrsoft/{{ name }}/get/{{ version }}.tar.gz
   # for versions based on an untagged git hash (required for v2021.07.1) use:
   #url: https://bitbucket.org/psrsoft/{{ name }}/get/d072c424de34f50d0627c4ca9f8b4ec40a791e07.tar.gz
+  url: https://bitbucket.org/psrsoft/${{ name }}/get/${{ version }}.tar.gz
   sha256: 25b8e164cda4637da1b479a837dfc5528821b5774073ccdb2c080fbcef826bd3
   patches:
     - 0001-package-m4.patch
@@ -19,19 +22,19 @@ source:
 
 build:
   number: 1
-  skip: true  # [win]
+  skip: win
 
 requirements:
   build:
-    - {{ compiler('cxx') }}
-    - {{ compiler('c') }}
-    - {{ stdlib("c") }}
-    - {{ compiler('fortran') }}
+    - ${{ compiler('cxx') }}
+    - ${{ compiler('c') }}
+    - ${{ stdlib("c") }}
+    - ${{ compiler('fortran') }}
     - autoconf
     - automake
     - gnuconfig
     - libtool
-    - make      # [unix]
+    - make
   host:
     - cfitsio
     - pgplot
@@ -39,7 +42,8 @@ requirements:
     - fftw
     - libblas
     - liblapack
-    - llvm-openmp  # [osx]
+    - if: osx
+      then: llvm-openmp
   run:
     - cfitsio
     - pgplot
@@ -47,26 +51,29 @@ requirements:
     - fftw
     - libblas
     - liblapack
-    - llvm-openmp  # [osx]
+    - if: osx
+      then: llvm-openmp
 
-test:
-  source_files:
-    - tests/test_data/test_de430.par
-    - tests/test_data/test_de430.tim
-  commands:
-    # skip tests for ppc64le is skipped
-    - tempo2 -f tests/test_data/test_de430.par tests/test_data/test_de430.tim  # [not ppc64le]
+tests:
+  - files:
+      source:
+        - tests/test_data/test_de430.par
+        - tests/test_data/test_de430.tim
+    script:
+      - if: not ppc64le
+        then: tempo2 -f tests/test_data/test_de430.par tests/test_data/test_de430.tim
 
 about:
-  home: https://bitbucket.org/psrsoft/tempo2/
+  homepage: https://bitbucket.org/psrsoft/tempo2/
+  repository: https://bitbucket.org/psrsoft/tempo2/
+  documentation: https://bitbucket.org/psrsoft/tempo2/src/${{ version }}/documentation/
   license: GPL-3.0-or-later
-  license_family: GPL
   license_file: COPYING
   summary: Tempo2 is a high precision pulsar timing tool. Tempo2 is not tempo3 either.
-  dev_url: https://bitbucket.org/psrsoft/tempo2/
 
 extra:
   recipe-maintainers:
     - demorest
     - sixbynine
     - mattpitkin
+

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -59,14 +59,14 @@ tests:
       source:
         - tests/test_data/test_de430.par
         - tests/test_data/test_de430.tim
-    script:
+  - script:
       - if: not ppc64le
         then: tempo2 -f tests/test_data/test_de430.par tests/test_data/test_de430.tim
 
 about:
-  homepage: https://bitbucket.org/psrsoft/tempo2/
-  repository: https://bitbucket.org/psrsoft/tempo2/
-  documentation: https://bitbucket.org/psrsoft/tempo2/src/${{ version }}/documentation/
+  homepage: https://bitbucket.org/psrsoft/tempo2
+  repository: https://bitbucket.org/psrsoft/tempo2
+  documentation: https://bitbucket.org/psrsoft/tempo2/src/${{ version }}/documentation
   license: GPL-3.0-or-later
   license_file: COPYING
   summary: Tempo2 is a high precision pulsar timing tool. Tempo2 is not tempo3 either.


### PR DESCRIPTION
- Add `osx-arm64` support and test configuration
- Migrate the recipe from `meta.yaml` to v1 `recipe.yaml` for faster building
- Add `gnuconfig`
- Build with `export CFLAGS="${CFLAGS} -std=gnu17"`
- Delete `conda_build_config.yaml` (`export CFLAGS="${CFLAGS} -std=gnu17"` works instead)
- Add documentation URL
- Refactor and expand package tests
- Add `run_exports` for `tempo2`

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
