### PR TITLE
Fix osx-arm64 precision and keep OpenMP enabled

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -25,7 +25,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '15'
+- '16'
 gsl:
 - '2.8'
 libblas:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - gcc
 c_compiler_version:
-- '15'
+- '16'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -19,13 +19,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '15'
+- '16'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '15'
+- '16'
 gsl:
 - '2.8'
 libblas:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -25,7 +25,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '16'
+- '15'
 gsl:
 - '2.8'
 libblas:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 MACOSX_SDK_VERSION:
 - '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
 - '21'
 c_stdlib:
@@ -17,7 +17,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
 - '21'
 fftw:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - gcc
 c_compiler_version:
-- '21'
+- 15
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -19,7 +19,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '21'
+- 15
 fftw:
 - '3'
 fortran_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - gcc
 c_compiler_version:
-- 15
+- '15'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -19,7 +19,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- 15
+- '15'
 fftw:
 - '3'
 fortran_compiler:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - gcc
 c_compiler_version:
-- '16'
+- '15'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -19,7 +19,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '16'
+- '15'
 fftw:
 - '3'
 fortran_compiler:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,17 +1,32 @@
 #! /bin/bash
 
-#./bootstrap
-#export CXXFLAGS=$(echo "$CXXFLAGS" | sed 's/-O2//' | perl -pe 's/-std=.+ /-std=c++98 /')
-#echo "CXXFLAGS $CXXFLAGS"
+set -exo pipefail
 
 export TEMPO2=$PREFIX/share/tempo2
+
+# GCC 15 and later default to C23, but Tempo2 still defines `bool`
+# itself in jpleph.c. Build the C sources as GNU C17 for compatibility.
 export CFLAGS="${CFLAGS} -std=gnu17"
+
+configure_args=()
+
+if [[ "${target_platform:-}" == "osx-arm64" ]]; then
+    # Apple Clang does not provide the __float128 arithmetic required by
+    # Tempo2 on arm64, so this target is built with GCC and libquadmath.
+    configure_args+=(--enable-float128)
+
+    # conda-forge's GCC for macOS uses libc++ but its bundled omp.h refers to libstdc++-specific headers.
+    # Put llvm-openmp's compatible header in a separate include directory so that it is found before GCC's omp.h.
+    mkdir -p "${SRC_DIR}/llvm-openmp-include"
+    cp "${PREFIX}/include/omp.h" "${SRC_DIR}/llvm-openmp-include/omp.h"
+    export CPPFLAGS="-I${SRC_DIR}/llvm-openmp-include ${CPPFLAGS:-}"
+fi
 
 # Get an updated config.sub and config.guess
 cp $BUILD_PREFIX/share/gnuconfig/config.* ./tests/gtest-1.7.0/build-aux
 
 ./bootstrap
-./configure --prefix=$PREFIX --disable-local --disable-psrhome PGPLOT_DIR=$PREFIX/include/pgplot
+./configure --prefix=${PREFIX} --disable-local --disable-psrhome PGPLOT_DIR=$PREFIX/include/pgplot ${configure_args[@]}
 make -j${CPU_COUNT}
 make install
 make -j${CPU_COUNT} plugins
@@ -20,7 +35,7 @@ make plugins-install
 # Copy runtime stuff
 for dir in atmosphere ephemeris example_data observatory plugin_data solarWindModel clock earth
 do
-    cp -a T2runtime/$dir $TEMPO2/
+    cp -a T2runtime/${dir} $TEMPO2/
 done
 
 # This foo will make conda automatically define a TEMPO2 env variable

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -26,7 +26,7 @@ fi
 cp $BUILD_PREFIX/share/gnuconfig/config.* ./tests/gtest-1.7.0/build-aux
 
 ./bootstrap
-./configure --prefix=${PREFIX} --disable-local --disable-psrhome PGPLOT_DIR=$PREFIX/include/pgplot ${configure_args[@]}
+./configure --prefix=${PREFIX} --disable-local --disable-psrhome PGPLOT_DIR=$PREFIX/include/pgplot "${configure_args[@]}"
 make -j${CPU_COUNT}
 make install
 make -j${CPU_COUNT} plugins

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -46,6 +46,8 @@ requirements:
   run:
     # `pgplot` does not provide run_exports
     - pgplot
+  run_exports:
+    - ${{ pin_subpackage("tempo2", upper_bound="x.x.x") }}
 
 tests:
   - package_contents:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -44,16 +44,8 @@ requirements:
     - if: osx
       then: llvm-openmp
   run:
-    - cfitsio
+    # `pgplot` does not provide run_exports
     - pgplot
-    - gsl
-    - fftw
-    - libblas
-    - liblapack
-    - if: osx
-      then: llvm-openmp
-  run_exports:
-    - ${{ pin_subpackage("tempo2", upper_bound="x.x.x") }}
 
 tests:
   - package_contents:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ source:
     - 0002-interpolate-std.patch
 
 build:
-  number: 1
+  number: 2
   skip: win
 
 requirements:
@@ -62,14 +62,12 @@ tests:
         - tempo2pred.h
         - T2toolkit.h
   - script:
-      # Run the precision regression test on every supported architecture.
-      # Merely checking the exit status is insufficient because Tempo2 also
-      # exits successfully when the calculated residual is inaccurate.
+      # Run the precision regression test on every supported architecture
+      # Merely checking the exit status is insufficient because Tempo2 also exits successfully when the calculated residual is inaccurate
       - OMP_NUM_THREADS=4 tempo2 -f tests/test_data/test_de430.par tests/test_data/test_de430.tim 2>&1 | tee tempo2-test.log
 
-      # Healthy builds produce a post-fit TRES of approximately 0.00125 us,
-      # while the affected osx-arm64 build produces approximately 0.32 us.
-      # Use 0.01 us as a deliberately loose cross-platform regression limit.
+      # Healthy builds produce a post-fit TRES of approximately 0.00125 us, while the affected osx-arm64 build produces approximately 0.32 us
+      # Use 0.01 us as a deliberately loose cross-platform regression limit
       - awk '$1 == "TRES" { found = 1; ok = ($3 > 0 && $3 < 0.01) } END { exit !(found && ok) }' tempo2-test.log
     files:
       source:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -25,10 +25,10 @@ build:
 
 requirements:
   build:
-    - ${{ compiler('cxx') }}
     - ${{ compiler('c') }}
-    - ${{ stdlib("c") }}
+    - ${{ compiler('cxx') }}
     - ${{ compiler('fortran') }}
+    - ${{ stdlib("c") }}
     - autoconf
     - automake
     - gnuconfig
@@ -36,11 +36,11 @@ requirements:
     - make
   host:
     - cfitsio
-    - pgplot
-    - gsl
     - fftw
+    - gsl
     - libblas
     - liblapack
+    - pgplot
     - if: osx
       then: llvm-openmp
   run:
@@ -70,8 +70,15 @@ tests:
         - tempo2pred.h
         - T2toolkit.h
   - script:
-      - if: not ppc64le
-        then: tempo2 -f tests/test_data/test_de430.par tests/test_data/test_de430.tim
+      # Run the precision regression test on every supported architecture.
+      # Merely checking the exit status is insufficient because Tempo2 also
+      # exits successfully when the calculated residual is inaccurate.
+      - OMP_NUM_THREADS=4 tempo2 -f tests/test_data/test_de430.par tests/test_data/test_de430.tim 2>&1 | tee tempo2-test.log
+
+      # Healthy builds produce a post-fit TRES of approximately 0.00125 us,
+      # while the affected osx-arm64 build produces approximately 0.32 us.
+      # Use 0.01 us as a deliberately loose cross-platform regression limit.
+      - awk '$1 == "TRES" { found = 1; ok = ($3 > 0 && $3 < 0.01) } END { exit !(found && ok) }' tempo2-test.log
     files:
       source:
         - tests/test_data/test_de430.par

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -6,16 +6,21 @@ c_compiler:
 cxx_compiler:
   - if: osx and arm64
     then: gxx
+fortran_compiler:
+  - if: osx and arm64
+    then: gfortran
 c_compiler_version:
   - if: osx and arm64
     then: '15'
 cxx_compiler_version:
   - if: osx and arm64
     then: '15'
-
-# Work around conda-forge/ctng-compilers-feedstock#225:
-# gfortran 15 can resolve with gcc_impl 16, causing -lemutls_w link failures.
-# Remove this pin after the dependency is fixed.
 fortran_compiler_version:
-  - if: osx
+  - if: osx and arm64
+    then: '15'
+
+  # Work around conda-forge/ctng-compilers-feedstock#225:
+  # gfortran 15 can resolve with gcc_impl 16 on osx-64, causing
+  # -lemutls_w link failures. Remove after the dependency is fixed.
+  - if: osx and x86_64
     then: "16"

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -1,0 +1,8 @@
+# Apple Clang's long double has only 53 mantissa bits on arm64
+# Use GCC and libquadmath so Tempo2 can enable `__float128` arithmetic
+c_compiler:
+  - if: osx and arm64
+    then: gcc
+cxx_compiler:
+  - if: osx and arm64
+    then: gxx

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -8,13 +8,13 @@ cxx_compiler:
     then: gxx
 c_compiler_version:
   - if: osx and arm64
-    then: 15
+    then: '15'
 cxx_compiler_version:
   - if: osx and arm64
-    then: 15
+    then: '15'
 gcc_compiler_version:
   - if: osx and arm64
-    then: 15
+    then: '15'
 gxx_compiler_version:
   - if: osx and arm64
-    then: 15
+    then: '15'

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -8,13 +8,14 @@ cxx_compiler:
     then: gxx
 c_compiler_version:
   - if: osx and arm64
-    then: '15'
+    then: '16'
 cxx_compiler_version:
   - if: osx and arm64
-    then: '15'
-gcc_compiler_version:
-  - if: osx and arm64
-    then: '15'
-gxx_compiler_version:
-  - if: osx and arm64
-    then: '15'
+    then: '16'
+
+# Work around conda-forge/ctng-compilers-feedstock#225:
+# gfortran 15 can resolve with gcc_impl 16, causing -lemutls_w link failures.
+# Remove this pin after the dependency is fixed.
+fortran_compiler_version:
+  - if: osx
+    then: "16"

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -8,10 +8,10 @@ cxx_compiler:
     then: gxx
 c_compiler_version:
   - if: osx and arm64
-    then: '16'
+    then: '15'
 cxx_compiler_version:
   - if: osx and arm64
-    then: '16'
+    then: '15'
 
 # Work around conda-forge/ctng-compilers-feedstock#225:
 # gfortran 15 can resolve with gcc_impl 16, causing -lemutls_w link failures.

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -6,3 +6,15 @@ c_compiler:
 cxx_compiler:
   - if: osx and arm64
     then: gxx
+c_compiler_version:
+  - if: osx and arm64
+    then: 15
+cxx_compiler_version:
+  - if: osx and arm64
+    then: 15
+gcc_compiler_version:
+  - if: osx and arm64
+    then: 15
+gxx_compiler_version:
+  - if: osx and arm64
+    then: 15


### PR DESCRIPTION
- Use GCC on `osx-arm64` and enable `__float128` support to avoid insufficient `long double` precision.
- Use the `llvm-openmp` header and runtime while keeping OpenMP enabled.
- Add a numerical regression test that detects the affected precision issue.
- Run the regression test on all supported platforms, including `linux-ppc64le`.
- Remove explicit runtime dependencies already provided through `run_exports`.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
