### PR TITLE
Update macOS compiler versions to 16 (ARM64) and drop x86_64 Fortran workaround

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -25,7 +25,7 @@ fftw:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '16'
+- '15'
 gsl:
 - '2.8'
 libblas:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - gcc
 c_compiler_version:
-- '15'
+- '16'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -19,13 +19,13 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '15'
+- '16'
 fftw:
 - '3'
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '15'
+- '16'
 gsl:
 - '2.8'
 libblas:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -20,7 +20,7 @@ source:
     - 0002-interpolate-std.patch
 
 build:
-  number: 2
+  number: 3
   skip: win
 
 requirements:

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -11,16 +11,10 @@ fortran_compiler:
     then: gfortran
 c_compiler_version:
   - if: osx and arm64
-    then: '15'
+    then: '16'
 cxx_compiler_version:
   - if: osx and arm64
-    then: '15'
+    then: '16'
 fortran_compiler_version:
   - if: osx and arm64
-    then: '15'
-
-  # Work around conda-forge/ctng-compilers-feedstock#225:
-  # gfortran 15 can resolve with gcc_impl 16 on osx-64, causing
-  # -lemutls_w link failures. Remove after the dependency is fixed.
-  - if: osx and x86_64
-    then: "16"
+    then: '16'


### PR DESCRIPTION
This pull request updates the compiler versions for macOS builds on ARM64 and x86_64 architectures in the `recipe/variants.yaml` file. The main changes are:

Compiler version updates:
* Updated the `c_compiler_version`, `cxx_compiler_version`, and `fortran_compiler_version` for macOS ARM64 from `'15'` to `'16'` to ensure consistency and compatibility with newer toolchains.

Cleanup of workaround:
* Removed a previous workaround for x86_64 that forced `fortran_compiler_version` to `'16'` due to a linking issue, as this is no longer necessary.

---

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
